### PR TITLE
Map API component outside the window component

### DIFF
--- a/frontend/src/Other Components/MoreDetailsMainPage.js
+++ b/frontend/src/Other Components/MoreDetailsMainPage.js
@@ -7,7 +7,8 @@ function MoreDetails(props) {
 
   const handleClose = () => setShow(false);
   const handleShow = () => setShow(true);
-
+  
+  // Xuejia Yang: The map api component exceeds the window component's boundary.
   return (
     <>
       <Button variant="primary" onClick={handleShow}>


### PR DESCRIPTION
It may be fixed by adjusting the pop up detail window size. This bug shows up when the user's screen size is large (work fine in a 13-inch screen but not on a 27-inch screen)
![Screen Shot 2021-12-02 at 12 36 12 PM](https://user-images.githubusercontent.com/26225083/144499925-cb8b1173-6209-44cc-9cef-3e28a15cb2d8.png)
