### PR TITLE
Unclear user name type

### DIFF
--- a/frontend/src/Account_Verification/create_account.js
+++ b/frontend/src/Account_Verification/create_account.js
@@ -75,7 +75,7 @@ function CreateAccount() {
           type="email"
           id="emailAddress"
           className="form-control"
-          placeholder="User Name"
+          placeholder="Email Address"
           name="username"
           value={user.username}
           onChange={usernameChange}


### PR DESCRIPTION
It is unclear that you want the user to use their email to be their user name.
I think it's better to just ask for the user's email since this is what you're using.  Using user name as label will confuse the user.